### PR TITLE
Add ruby and nodejs on alpine linux

### DIFF
--- a/Dockerfile 
+++ b/Dockerfile 
@@ -1,0 +1,6 @@
+FROM ruby:2.4.1-alpine
+
+WORKDIR /app
+
+# Update the Package Install nodejs
+RUN apk update && apk add --no-cache nodejs-6.10.3-r0


### PR DESCRIPTION
# what
- alpine linux上にrubyが入っているimageに、nodejsを追加する記述をしたDockerfileを作成
- README.mdに説明を追加
# why
repro-visitorsの運用上、werckerのboxとして利用するためにdocker imageを作成する必要があるから