### PR TITLE
Add ruby and nodejs on debian

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,3 @@
+## How to contribute to Ruby and Node
+- pullrequestを出すときはreviewerに@tenshotanakaと@threetreeslighthをassign
+

--- a/Dockerfile 
+++ b/Dockerfile 
@@ -1,0 +1,34 @@
+FROM ruby:2.4.1
+
+# implementation refers https://github.com/nodejs/docker-node/blob/master/6.10/Dockerfile
+RUN groupadd --gid 1000 node \
+  && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
+
+# gpg keys listed at https://github.com/nodejs/node#release-team
+RUN set -ex \
+  && for key in \
+    9554F04D7259F04124DE6B476D5A82AC7E37093B \
+    94AE36675C464D64BAFA68DD7434390BDBE9B9C5 \
+    FD3A5288F042B6850C66B31F09FE44734EB7990E \
+    71DCFD284A79C3B38668286BC97EC7A07EDE3FC1 \
+    DD8F2338BAE7501E3DD5AC78C273792F7D83545D \
+    B9AE9905FFD7803F25714661B63B535A4C206CA9 \
+    C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8 \
+    56730D5401028683275BD23C23EFEFE93C4CFFFE \
+  ; do \
+    gpg --keyserver pgp.mit.edu --recv-keys "$key" || \
+    gpg --keyserver keyserver.pgp.com --recv-keys "$key" || \
+    gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key" ; \
+  done
+
+ENV NPM_CONFIG_LOGLEVEL info
+ENV NODE_VERSION 6.10.3
+
+RUN curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.xz" \
+  && curl -SLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \
+  && gpg --batch --decrypt --output SHASUMS256.txt SHASUMS256.txt.asc \
+  && grep " node-v$NODE_VERSION-linux-x64.tar.xz\$" SHASUMS256.txt | sha256sum -c - \
+  && tar -xJf "node-v$NODE_VERSION-linux-x64.tar.xz" -C /usr/local --strip-components=1 \
+  && rm "node-v$NODE_VERSION-linux-x64.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt \
+  && ln -s /usr/local/bin/node /usr/local/bin/nodejs
+# end of reference

--- a/README.md
+++ b/README.md
@@ -1,1 +1,8 @@
 # ruby-and-node
+This is the Docker image ruby:2.4.1 and node:6.10.3 are installed on debian.
+
+## Tag naming conventions
+ruby-#{ruby-version}-and-node-#{node-version}
+
+## docker hub link
+https://hub.docker.com/r/tenshotanaka/ruby-and-node/


### PR DESCRIPTION
# what
- debian上でrubyのimageに、nodejsを追加する記述をしたDockerfileを作成
- README.mdに説明を追加
# why
repro-visitorsの運用上、werckerのboxとして利用するためにdocker imageを作成する必要があるから

# rules
- pullrequestを出すときはreviewerに@tenshotanakaと@threetreeslighthをassign
- tagの命名規則はruby-#{ruby-version}-and-node-#{node-version}とする